### PR TITLE
Add automatic login script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ python web_voyager.py
 ```
 
 **_NOTE:_**  If a CAPTCHA is encountered during browsing, please solve it manually in the browser window.
+## 🔐 Automatic Login
+Run `login_agent.py` to log in to any website automatically:
+```bash
+python login_agent.py --url <login_page> --username <user> --password <pass>
+```
+

--- a/login_agent.py
+++ b/login_agent.py
@@ -1,0 +1,25 @@
+import argparse
+import asyncio
+from playwright.async_api import async_playwright
+from web_voyager import call_agent
+
+async def auto_login(url: str, username: str, password: str):
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=False)
+        page = await browser.new_page()
+        await page.goto(url)
+        prompt = (
+            f"Login to this website using username '{username}' and password '{password}'. "
+            "After logging in, respond with 'ANSWER: done'."
+        )
+        answer = await call_agent(prompt, page)
+        print("Agent answer:", answer)
+        await browser.close()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Automatic login using Web Voyager agent")
+    parser.add_argument("--url", required=True, help="Login page URL")
+    parser.add_argument("--username", required=True, help="Username")
+    parser.add_argument("--password", required=True, help="Password")
+    args = parser.parse_args()
+    asyncio.run(auto_login(args.url, args.username, args.password))


### PR DESCRIPTION
## Summary
- implement `login_agent.py` to automate logging in using the existing Web Voyager agent
- document how to run the new login script

## Testing
- `python -m py_compile login_agent.py`
- `python login_agent.py --url https://example.com --username foo --password bar` *(fails: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_b_6864910b781c83338a78010cf08ad86e